### PR TITLE
Body may only contain the assistant.id

### DIFF
--- a/src/server/runs.ts
+++ b/src/server/runs.ts
@@ -89,7 +89,9 @@ app.openapi(routes.createRun, async (c) => {
       // @ts-ignore tools may be overridden by params
       tools: assistant.tools,
       file_ids: assistant.file_ids,
-      ...utils.convertOAIToPrisma(body),
+      assistant_id: assistant.id,
+      instructions: assistant.instructions || '',
+      model: assistant.model,
       thread_id,
       status: 'queued' as const,
       expires_at: new Date(now + config.runs.maxRunTime)


### PR DESCRIPTION
When I tried using the project I encountered exceptions in `run.ts` in `prisma.run.create` complaining that `instructions` and `model` are not set (in effect in my API call using the official OpenAI Python client the instructions and models are not passed, only the assistant_id).
My calling code is as follows:
```
        run = self.client.beta.threads.runs.create(thread_id=thread_id, assistant_id=self.assistant_id)
```

I believe it is more correct to read those from the assistant that has already been created and hydrated a few lines above?

